### PR TITLE
Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ hoomd_validation/__pycache__
 hoomd_validation/config.json
 signac.rc
 signac_project_document.json
+.signac_sp_cache.json.gz

--- a/README.md
+++ b/README.md
@@ -83,4 +83,13 @@ documents:
 3. Inspect the plots produced in:
     * `workspace/*.svg`
 
+## Dashboard
+
+Run the provided [signac-dashboard] application to explore the results in a web browser:
+
+```bash
+$ python3 dashboard.py run
+```
+
 [glotzerlab-software container]: https://glotzerlab-software.readthedocs.io/
+[signac-dashboard]: https://docs.signac.io/projects/dashboard/

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ validation test workflows in this repository are organized into signac projects.
 
 ## Requirements
 
+* numpy
 * signac >=1.8.0
 * signac-flow >= 0.22.0
-* numpy
+* signac-dashboard [optional]
 * Simulation workflow steps require either the [glotzerlab-software container]
   or the following software:
     * HOOMD-blue >=3.0 *(with MPI, GPU, and LLVM support enabled)*

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Dashboard."""
+
+from signac_dashboard import Dashboard
+from signac_dashboard.modules import StatepointList, ImageViewer
+
+modules = [
+    StatepointList(),
+    ImageViewer(context="JobContext", img_globs=("*.png", "*.jpg", "*.gif", "*.svg")),
+    ImageViewer(context="ProjectContext", img_globs=("*.png", "*.jpg", "*.gif", "*.svg")),
+]
+
+class ValidationDashboard(Dashboard):
+    """Dashboard application."""
+
+    def job_title(self, job):
+        if job.statepoint.subproject == 'lj_fluid':
+            return f"lj_fluid: kT={job.statepoint.kT}, rho={job.statepoint.density}"
+        elif job.statepoint.subproject == 'hard_disk':
+            return f"{job.statepoint.subproject}: rho={job.statepoint.density}"
+        else:
+            raise RuntimeError("Unexpected job")
+
+if __name__ == "__main__":
+    ValidationDashboard(modules=modules).main()

--- a/dashboard.py
+++ b/dashboard.py
@@ -8,20 +8,26 @@ from signac_dashboard.modules import StatepointList, ImageViewer
 
 modules = [
     StatepointList(),
-    ImageViewer(context="JobContext", img_globs=("*.png", "*.jpg", "*.gif", "*.svg")),
-    ImageViewer(context="ProjectContext", img_globs=("*.png", "*.jpg", "*.gif", "*.svg")),
+    ImageViewer(context="JobContext",
+                img_globs=("*.png", "*.jpg", "*.gif", "*.svg")),
+    ImageViewer(context="ProjectContext",
+                img_globs=("*.png", "*.jpg", "*.gif", "*.svg")),
 ]
+
 
 class ValidationDashboard(Dashboard):
     """Dashboard application."""
 
     def job_title(self, job):
+        """Name jobs."""
         if job.statepoint.subproject == 'lj_fluid':
-            return f"lj_fluid: kT={job.statepoint.kT}, rho={job.statepoint.density}"
+            return f"lj_fluid: kT={job.statepoint.kT}, " \
+                   f"rho={job.statepoint.density}"
         elif job.statepoint.subproject == 'hard_disk':
             return f"{job.statepoint.subproject}: rho={job.statepoint.density}"
         else:
             raise RuntimeError("Unexpected job")
+
 
 if __name__ == "__main__":
     ValidationDashboard(modules=modules).main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 signac >= 1.8.0
 signac-flow >= 1.22.0
+signac-dashboard
 matplotlib
 gsd
 numpy


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add signac-dashboard application.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to browse results of the simulations.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #7

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the dashboard application locally.

If you would like to run the dashboard and check it out, there is some data in `/nfs/turbo/glotzer/hoomd-validation/hard-sphere-eos/2022-11-02` from #18, along with `dashboard.py` from this branch.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.

## Timing

Merge after #14