### PR TITLE
Add LJ energy and momentum conservation tests.

### DIFF
--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -967,8 +967,8 @@ def lj_fluid_nve_md_gpu(job):
     lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_cpu_complete'))
 @Project.pre(
     lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_gpu_complete'))
-@Project.post(lambda *jobs: util.true_all(
-    *jobs, key='lj_fluid_conservation_analysis_complete'))
+@Project.post(lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS],
+    key='lj_fluid_conservation_analysis_complete'))
 def lj_fluid_conservation_analyze(*jobs):
     """Analyze the output of NVE simulations and inspect conservation."""
     import gsd.hoomd
@@ -1005,14 +1005,13 @@ def lj_fluid_conservation_analyze(*jobs):
                 job_energies[sim_mode]
                 - job_energies[sim_mode][0]) / job.statepoint["num_particles"]
 
-        energies.append(job_energies)
-
-        for sim_mode in sim_modes:
             momentum_vector = get_log_quantity(traj,
                                                'md/Integrator/linear_momentum')
             job_linear_momentum[sim_mode] = [
                 math.sqrt(v[0]**2 + v[1]**2 + v[2]**2) for v in momentum_vector
             ]
+
+        energies.append(job_energies)
 
         linear_momenta.append(job_linear_momentum)
 

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -961,9 +961,9 @@ def lj_fluid_nve_md_gpu(job):
 @agg
 @Project.operation(directives=dict(walltime=1, executable=CONFIG["executable"]))
 @Project.pre(
-    lambda *jobs: util.true_all(jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_cpu_complete'))
+    lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_cpu_complete'))
 @Project.pre(
-    lambda *jobs: util.true_all(jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_gpu_complete'))
+    lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_gpu_complete'))
 @Project.post(lambda *jobs: util.true_all(
     *jobs, key='lj_fluid_conservation_analysis_complete'))
 def lj_fluid_conservation_analyze(*jobs):

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -20,6 +20,7 @@ LJ_PARAMS = {'epsilon': 1.0, 'sigma': 1.0, 'r_on': 2.0, 'r_cut': 2.5}
 # Limit the number of long NVE runs to reduce the number of CPU hours needed.
 NUM_NVE_RUNS = 2
 
+
 def job_statepoints():
     """list(dict): A list of statepoints for this subproject."""
     num_particles = 12**3
@@ -963,12 +964,12 @@ def lj_fluid_nve_md_gpu(job):
 
 @agg
 @Project.operation(directives=dict(walltime=1, executable=CONFIG["executable"]))
-@Project.pre(
-    lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_cpu_complete'))
-@Project.pre(
-    lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS], key='lj_fluid_nve_md_gpu_complete'))
-@Project.post(lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS],
-    key='lj_fluid_conservation_analysis_complete'))
+@Project.pre(lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS],
+                                         key='lj_fluid_nve_md_cpu_complete'))
+@Project.pre(lambda *jobs: util.true_all(*jobs[0:NUM_NVE_RUNS],
+                                         key='lj_fluid_nve_md_gpu_complete'))
+@Project.post(lambda *jobs: util.true_all(
+    *jobs[0:NUM_NVE_RUNS], key='lj_fluid_conservation_analysis_complete'))
 def lj_fluid_conservation_analyze(*jobs):
     """Analyze the output of NVE simulations and inspect conservation."""
     import gsd.hoomd

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -133,9 +133,13 @@ def make_md_simulation(job,
 
     # add gsd log quantities
     logger = hoomd.logging.Logger(categories=['scalar', 'sequence'])
-    logger.add(
-        thermo,
-        quantities=['pressure', 'potential_energy', 'kinetic_temperature'])
+    logger.add(thermo,
+               quantities=[
+                   'pressure',
+                   'potential_energy',
+                   'kinetic_temperature',
+                   'kinetic_energy',
+               ])
     logger.add(integrator, quantities=['linear_momentum'])
     for loggable in extra_loggables:
         logger.add(loggable)
@@ -783,9 +787,12 @@ def lj_fluid_analyze(job):
     job.document['lj_fluid_analysis_complete'] = True
 
 
-@aggregator.groupby(key=['kT', 'density', 'num_particles'],
-                    sort_by='replicate_idx',
-                    select=is_lj_fluid)
+agg = aggregator.groupby(key=['kT', 'density', 'num_particles'],
+                         sort_by='replicate_idx',
+                         select=is_lj_fluid)
+
+
+@agg
 @Project.operation(directives=dict(executable=CONFIG["executable"]))
 @Project.pre(
     lambda *jobs: util.true_all(*jobs, key='lj_fluid_analysis_complete'))
@@ -883,3 +890,137 @@ def lj_fluid_compare_modes(*jobs):
 
     for job in jobs:
         job.document['lj_fluid_compare_modes_complete'] = True
+
+
+def run_nve_md_sim(job, device):
+    """Run the MD simulation in NVE."""
+    import hoomd
+
+    initial_state = job.fn('lj_fluid_initial_state.gsd')
+    nvt = hoomd.md.methods.NVE(hoomd.filter.All())
+    sim_mode = 'nve_md'
+
+    sim = make_md_simulation(job, device, initial_state, nvt, sim_mode)
+
+    # Run for a long time to look for energy and momentum drift
+    device.notice('Running...')
+    sim.run(RUN_STEPS * 20)
+    device.notice('Done.')
+
+
+@Project.operation(directives=dict(walltime=48,
+                                   executable=CONFIG["executable"],
+                                   nranks=8))
+@Project.pre.after(lj_fluid_create_initial_state)
+@Project.post.true('lj_fluid_nve_md_cpu_complete')
+def lj_fluid_nve_md_cpu(job):
+    """Run NVE MD on the CPU."""
+    import hoomd
+    device = hoomd.device.CPU(msg_file=job.fn('run_nve_md_cpu.log'))
+    run_nve_md_sim(job, device)
+
+    if device.communicator.rank == 0:
+        job.document['lj_fluid_nve_md_cpu_complete'] = True
+
+
+@Project.operation(directives=dict(walltime=48,
+                                   executable=CONFIG["executable"],
+                                   nranks=1,
+                                   ngpu=1))
+@Project.pre.after(lj_fluid_create_initial_state)
+@Project.post.true('lj_fluid_nve_md_gpu_complete')
+def lj_fluid_nve_md_gpu(job):
+    """Run NVE MD on the GPU."""
+    import hoomd
+    device = hoomd.device.GPU(msg_file=job.fn('run_nve_md_gpu.log'))
+    run_nve_md_sim(job, device)
+
+    if device.communicator.rank == 0:
+        job.document['lj_fluid_nve_md_gpu_complete'] = True
+
+
+@agg
+@Project.operation(directives=dict(walltime=1, executable=CONFIG["executable"]))
+@Project.pre(
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_nve_md_cpu_complete'))
+@Project.pre(
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_nve_md_gpu_complete'))
+@Project.post(lambda *jobs: util.true_all(
+    *jobs, key='lj_fluid_conservation_analysis_complete'))
+def lj_fluid_conservation_analyze(*jobs):
+    """Analyze the output of NVE simulations and inspect conservation."""
+    import gsd.hoomd
+    import numpy
+    import math
+    import matplotlib
+    import matplotlib.style
+    import matplotlib.figure
+    matplotlib.style.use('ggplot')
+    from util import read_gsd_log_trajectory, get_log_quantity
+
+    sim_modes = ['nve_md_cpu', 'nve_md_gpu']
+
+    energies = []
+    linear_momenta = []
+
+    for job in jobs:
+        job_energies = {}
+        job_linear_momentum = {}
+
+        for sim_mode in sim_modes:
+            with gsd.hoomd.open(job.fn(sim_mode
+                                       + '_quantities.gsd')) as gsd_traj:
+                # read GSD file once
+                traj = read_gsd_log_trajectory(gsd_traj)
+
+            job_energies[sim_mode] = (
+                get_log_quantity(
+                    traj, 'md/compute/ThermodynamicQuantities/potential_energy')
+                + get_log_quantity(
+                    traj, 'md/compute/ThermodynamicQuantities/kinetic_energy'))
+            job_energies[sim_mode] = (
+                job_energies[sim_mode]
+                - job_energies[sim_mode][0]) / job.statepoint["num_particles"]
+
+        energies.append(job_energies)
+
+        for sim_mode in sim_modes:
+            momentum_vector = get_log_quantity(traj,
+                                               'md/Integrator/linear_momentum')
+            job_linear_momentum[sim_mode] = [
+                math.sqrt(v[0]**2 + v[1]**2 + v[2]**2) for v in momentum_vector
+            ]
+
+        linear_momenta.append(job_linear_momentum)
+
+    # Plot results
+    def plot(*, ax, data, quantity_name, legend=False):
+        for i, job in enumerate(jobs):
+            for mode in sim_modes:
+                ax.plot(numpy.asarray(data[i][mode]),
+                        label=f'{mode}_{job.statepoint.replicate_idx}')
+        ax.set_xlabel("frame")
+        ax.set_ylabel(quantity_name)
+
+        if legend:
+            ax.legend()
+
+    fig = matplotlib.figure.Figure(figsize=(10, 10 / 1.68 * 2), layout='tight')
+    ax = fig.add_subplot(2, 1, 1)
+    plot(ax=ax, data=energies, quantity_name=r"$E / N$", legend=True)
+
+    ax = fig.add_subplot(2, 1, 2)
+    plot(ax=ax, data=linear_momenta, quantity_name=r"$p$")
+
+    fig.suptitle("LJ conservation tests: "
+                 f"$kT={job.statepoint.kT}$, $\\rho={job.statepoint.density}$, "
+                 f"$N={job.statepoint.num_particles}$")
+    filename = f'lj_fluid_conservation_kT{job.statepoint.kT}_' \
+               f'density{job.statepoint.density}_' \
+               f'N{job.statepoint.num_particles}.svg'
+
+    fig.savefig(os.path.join(jobs[0]._project.path, filename),
+                bbox_inches='tight')
+
+    for job in jobs:
+        job.document['lj_fluid_conservation_analysis_complete'] = True

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -1036,7 +1036,7 @@ def lj_fluid_conservation_analyze(*jobs):
                  f"$kT={job.statepoint.kT}$, $\\rho={job.statepoint.density}$, "
                  f"$N={job.statepoint.num_particles}$")
     filename = f'lj_fluid_conservation_kT{job.statepoint.kT}_' \
-               f'density{round(job.statepoint.density, 2)_' \
+               f'density{round(job.statepoint.density, 2)}_' \
                f'N{job.statepoint.num_particles}.svg'
 
     fig.savefig(os.path.join(jobs[0]._project.path, filename),


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Run long NVE simulations (200e6 steps on the CPU, 800e6 on the GPU) and check for energy and momentum conservation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Ensure that HOOMD-blue's computations are accurate.

To reduce the amount of compute time needed to complete, the NVE runs only on the first 2 replicates.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I ran the workflow on Great Lakes. See the data here:
`/nfs/turbo/glotzer/hoomd-validation/lj-conservation/2022-11-03`

Example output:

![lj_fluid_conservation_kT1 0_density0 8_N1728 (1)](https://user-images.githubusercontent.com/2197568/199736200-3df7ca74-9475-4a78-812e-7feed1c96c42.svg)

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
