### PR TITLE
Kinetic energy validation

### DIFF
--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -914,18 +914,18 @@ def lj_fluid_compare_modes(*jobs):
 @Project.operation(directives=dict(executable=CONFIG["executable"]))
 @Project.pre(
     lambda *jobs: util.true_all(*jobs, key='lj_fluid_langevin_md_cpu_complete'))
-# @Project.pre(
-#     lambda *jobs: util.true_all(*jobs, key='lj_fluid_langevin_md_gpu_complete'))
+@Project.pre(
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_langevin_md_gpu_complete'))
 @Project.pre(
     lambda *jobs: util.true_all(*jobs, key='lj_fluid_nvt_md_cpu_complete'))
-# @Project.pre(
-#     lambda *jobs: util.true_all(*jobs, key='lj_fluid_nvt_md_gpu_complete'))
+@Project.pre(
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_nvt_md_gpu_complete'))
 @Project.pre(
     lambda *jobs: util.true_all(*jobs, key='lj_fluid_npt_md_cpu_complete'))
-# @Project.pre(
-#     lambda *jobs: util.true_all(*jobs, key='lj_fluid_npt_md_gpu_complete'))
-# @Project.post(
-#     lambda *jobs: util.true_all(*jobs, key='lj_fluid_ke_validate_complete'))
+@Project.pre(
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_npt_md_gpu_complete'))
+@Project.post(
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_ke_validate_complete'))
 def lj_fluid_ke_validate(*jobs):
     """Checks that MD follows the correct KE distribution."""
     import gsd.hoomd
@@ -936,13 +936,9 @@ def lj_fluid_ke_validate(*jobs):
     import util
     matplotlib.style.use('ggplot')
 
-    # sim_modes = [
-    #     'langevin_md_cpu', 'langevin_md_gpu', 'nvt_md_cpu', 'nvt_md_gpu',
-    #     'npt_md_cpu', 'npt_md_gpu'
-    # ]
     sim_modes = [
-        'langevin_md_cpu', 'nvt_md_cpu',
-        'npt_md_cpu',
+        'langevin_md_cpu', 'langevin_md_gpu', 'nvt_md_cpu', 'nvt_md_gpu',
+        'npt_md_cpu', 'npt_md_gpu'
     ]
 
     # grab the common statepoint parameters

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -959,18 +959,16 @@ def lj_fluid_ke_validate(*jobs):
                                        + '_quantities.gsd')) as gsd_traj:
                 traj = util.read_gsd_log_trajectory(gsd_traj)
 
-                ke = util.get_log_quantity(traj, 'md/compute/ThermodynamicQuantities/kinetic_energy')
+                ke = util.get_log_quantity(
+                    traj, 'md/compute/ThermodynamicQuantities/kinetic_energy')
                 ke_means[sim_mode].append(numpy.mean(ke[-FRAMES_ANALYZE:]))
                 ke_sigmas[sim_mode].append(numpy.std(ke[-FRAMES_ANALYZE:]))
 
     def plot_vs_expected(ax, values, expected, name):
         # compute stats with data
-        avg_value = {
-            mode: numpy.mean(values[mode]) for mode in sim_modes
-        }
+        avg_value = {mode: numpy.mean(values[mode]) for mode in sim_modes}
         stderr_value = {
-            mode:
-            2 * numpy.std(values[mode]) / numpy.sqrt(len(values[mode]))
+            mode: 2 * numpy.std(values[mode]) / numpy.sqrt(len(values[mode]))
             for mode in sim_modes
         }
 
@@ -993,11 +991,13 @@ def lj_fluid_ke_validate(*jobs):
                   colors='k')
 
     ax = fig.add_subplot(2, 1, 1)
-    plot_vs_expected(ax, ke_means, 1/2 * n_dof * kT, '$<KE> - 1/2 N_{dof} k T$')
+    plot_vs_expected(ax, ke_means, 1 / 2 * n_dof * kT,
+                     '$<KE> - 1/2 N_{dof} k T$')
 
     ax = fig.add_subplot(2, 1, 2)
     # https://doi.org/10.1371/journal.pone.0202764
-    plot_vs_expected(ax, ke_sigmas, 1/math.sqrt(2) * math.sqrt(n_dof) * kT, r'$\Delta KE - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
+    plot_vs_expected(ax, ke_sigmas, 1 / math.sqrt(2) * math.sqrt(n_dof) * kT,
+                     r'$\Delta KE - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
 
     filename = f'lj_fluid_ke_validate_kT{kT}_density{round(set_density, 2)}.svg'
     fig.savefig(os.path.join(jobs[0]._project.path, filename),

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -1000,7 +1000,7 @@ def lj_fluid_ke_validate(*jobs):
     plot_vs_expected(ax, ke_means, 1/2 * n_dof * kT, '$<KE> - 1/2 N_{dof} k T$')
 
     ax = fig.add_subplot(2, 1, 2)
-    # https://doi.org/10.26434/chemrxiv.6005279.v2
+    # https://doi.org/10.1371/journal.pone.0202764
     plot_vs_expected(ax, ke_sigmas, 1/math.sqrt(2) * math.sqrt(n_dof) * kT, r'$\Delta KE - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
 
     filename = f'lj_fluid_ke_validate_kT{kT}_density{round(set_density, 2)}.svg'


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add an output plot that validates the KE energy distribution shape.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some integrators (i.e. Berendsen) sample the correct mean, but the incorrect shape of the distribution. While our state point MC cross check tests should catch errors here, directly examining the shape of the KE distribution is useful. For more details, see the "kinetic energy validation" section of this paper https://doi.org/10.1371/journal.pone.0202764.

I implemented the std deviation check because it is simpler and the paper shows it is more than sufficient to show Berendsen is a poor integrator. The full Kolmogorov-Smirnov test would be more accurate, but is significantly more complex to implement and interpret the results from.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I ran the workflow on Great Lakes.

Sample output:
![lj_fluid_ke_validate_kT1 0_density0 8](https://user-images.githubusercontent.com/2197568/202502038-b550a01f-e96b-4e91-b8aa-bfb1df471d18.svg)

Data from the run is available to Glotzer group members at: /nfs/turbo/glotzer/hoomd-validation/ke-validation/2022-11-17

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
