### PR TITLE
Use pre-commit.ci to run pre-commit checks.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,22 +18,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # for now the repo is private, so pre-commit won't run automatically
-  pre-commit:
-    name: pre-commit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3.1.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v4.3.0
-        with:
-          python-version: '3.10'
-
-      - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.0
-
   flow-status:
     name: flow-status
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Remove pre-commit from GitHub actions configuration.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
As a public repository, we can now use pre-commit.ci.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
We should see pre-commit.ci check results in this pull request.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
