### PR TITLE
Support `ENABLE_LLVM=off`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ validation test workflows in this repository are organized into signac projects.
 * signac-dashboard [optional]
 * Simulation workflow steps require either the [glotzerlab-software container]
   or the following software:
-    * HOOMD-blue >=3.0 *(with MPI, GPU, and LLVM support enabled)*
+    * HOOMD-blue >=3.0 *(with MPI and GPU support enabled, LLVM support is optional)*,
 * Analysis workflow steps require either the [glotzerlab-software container] or
   the following software:
     * matplotlib

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -942,8 +942,8 @@ def lj_fluid_compare_modes(*jobs):
 @Project.pre(
     lambda *jobs: util.true_all(*jobs, key='lj_fluid_npt_md_gpu_complete'))
 @Project.post(
-    lambda *jobs: util.true_all(*jobs, key='lj_fluid_ke_validate_complete'))
-def lj_fluid_ke_validate(*jobs):
+    lambda *jobs: util.true_all(*jobs, key='lj_fluid_ke_analyze_complete'))
+def lj_fluid_ke_analyze(*jobs):
     """Checks that MD follows the correct KE distribution."""
     import gsd.hoomd
     import numpy
@@ -1016,12 +1016,12 @@ def lj_fluid_ke_validate(*jobs):
     plot_vs_expected(ax, ke_sigmas, 1 / math.sqrt(2) * math.sqrt(n_dof) * kT,
                      r'$\Delta KE - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
 
-    filename = f'lj_fluid_ke_validate_kT{kT}_density{round(set_density, 2)}.svg'
+    filename = f'lj_fluid_ke_analyze_kT{kT}_density{round(set_density, 2)}.svg'
     fig.savefig(os.path.join(jobs[0]._project.path, filename),
                 bbox_inches='tight')
 
     for job in jobs:
-        job.document['lj_fluid_ke_validate_complete'] = True
+        job.document['lj_fluid_ke_analyze_complete'] = True
 
 
 def run_nve_md_sim(job, device, run_length):

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -469,6 +469,12 @@ def make_mc_simulation(job,
 
 def run_nvt_mc_sim(job, device):
     """Run MC sim in NVT."""
+    import hoomd
+
+    if not hoomd.version.llvm_enabled:
+        device.notice("LLVM disabled, skipping MC simulations.")
+        return
+
     # simulation
     initial_state = job.fn('lj_fluid_initial_state.gsd')
     sim_mode = 'nvt_mc'
@@ -528,6 +534,10 @@ def run_npt_mc_sim(job, device):
     import hoomd
     from hoomd import hpmc
     from custom_actions import ComputeDensity
+
+    if not hoomd.version.llvm_enabled:
+        device.notice("LLVM disabled, skipping MC simulations.")
+        return
 
     # device
     initial_state = job.fn('lj_fluid_initial_state.gsd')
@@ -634,8 +644,11 @@ def lj_fluid_analyze(job):
     )
     sim_modes = [
         'langevin_md_cpu', 'langevin_md_gpu', 'nvt_md_cpu', 'nvt_md_gpu',
-        'npt_md_cpu', 'npt_md_gpu', 'nvt_mc_cpu', 'nvt_mc_gpu', 'npt_mc_cpu'
+        'npt_md_cpu', 'npt_md_gpu',
     ]
+
+    if os.path.exists(job.fn('nvt_mc_cpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_cpu', 'nvt_mc_gpu', 'npt_mc_cpu'])
 
     energies = {}
     pressures = {}
@@ -827,8 +840,12 @@ def lj_fluid_compare_modes(*jobs):
 
     sim_modes = [
         'langevin_md_cpu', 'langevin_md_gpu', 'nvt_md_cpu', 'nvt_md_gpu',
-        'npt_md_cpu', 'npt_md_gpu', 'nvt_mc_cpu', 'nvt_mc_gpu', 'npt_mc_cpu'
+        'npt_md_cpu', 'npt_md_gpu',
     ]
+
+    if os.path.exists(jobs[0].fn('nvt_mc_cpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_cpu', 'nvt_mc_gpu', 'npt_mc_cpu'])
+
     quantity_names = ['density', 'pressure', 'potential_energy']
 
     # grab the common statepoint parameters

--- a/hoomd_validation/lj_fluid.py
+++ b/hoomd_validation/lj_fluid.py
@@ -643,8 +643,12 @@ def lj_fluid_analyze(job):
         npt_mc_gpu='pressure',
     )
     sim_modes = [
-        'langevin_md_cpu', 'langevin_md_gpu', 'nvt_md_cpu', 'nvt_md_gpu',
-        'npt_md_cpu', 'npt_md_gpu',
+        'langevin_md_cpu',
+        'langevin_md_gpu',
+        'nvt_md_cpu',
+        'nvt_md_gpu',
+        'npt_md_cpu',
+        'npt_md_gpu',
     ]
 
     if os.path.exists(job.fn('nvt_mc_cpu_quantities.gsd')):
@@ -839,8 +843,12 @@ def lj_fluid_compare_modes(*jobs):
     matplotlib.style.use('ggplot')
 
     sim_modes = [
-        'langevin_md_cpu', 'langevin_md_gpu', 'nvt_md_cpu', 'nvt_md_gpu',
-        'npt_md_cpu', 'npt_md_gpu',
+        'langevin_md_cpu',
+        'langevin_md_gpu',
+        'nvt_md_cpu',
+        'nvt_md_gpu',
+        'npt_md_cpu',
+        'npt_md_gpu',
     ]
 
     if os.path.exists(jobs[0].fn('nvt_mc_cpu_quantities.gsd')):


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Allow the workflow to run with HOOMD installations built with `ENABLE_LLVM=off`. I do this by skipping the workflow steps that use pair potentials in HPMC and leaving those runs out of the analysis.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The workflow can run and complete on AMD GPUs. `ENABLE_LLVM=on` is not currently possible on AMD GPUs.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I am running the workflow with `ENABLE_LLVM=off` now.

## TODO:

* [x] Run workflow with `ENABLE_LLVM=on` and ensure that the MC runs are included.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
