### PR TITLE
Bump signac and signac-flow

### DIFF
--- a/.github/workflows/requirements-test.txt
+++ b/.github/workflows/requirements-test.txt
@@ -1,5 +1,5 @@
-signac==1.8.0
-signac-flow==0.24.0
+signac==2.0.0
+signac-flow==0.25.1
 numpy==1.24.2
 PyYAML==6.0
 gsd==2.8.0

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ hoomd_validation/config.json
 signac.rc
 signac_project_document.json
 .signac_sp_cache.json.gz
+__pycache__
+.signac

--- a/hoomd_validation/init.py
+++ b/hoomd_validation/init.py
@@ -15,7 +15,7 @@ import hard_sphere
 
 subprojects = [alj_2d, lj_fluid, hard_disk, hard_sphere]
 
-project = signac.init_project(root=config.project_root)
+project = signac.init_project(path=config.project_root)
 
 # initialize jobs for validation test projects
 for subproject in subprojects:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-signac >= 1.8.0
-signac-flow >= 1.22.0
+signac >= 2.0.0
+signac-flow >= 0.25.1
 signac-dashboard
 matplotlib
 gsd


### PR DESCRIPTION
## Description

This PR bumps both `signac` and `signac-flow`, taking the place of #47 and #48 . It also fixes a typo in `requirements.txt`

## Motivation and context

Bumping `signac` and `signac-flow` individually will necessary cause errors, due to the major version bump in `signac` and the new version requirements established between the packages.

## How has this been tested?

If CI tests pass, we are good to go.

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
