### PR TITLE
Refactor `lj-union`.

### DIFF
--- a/hoomd_validation/init.py
+++ b/hoomd_validation/init.py
@@ -14,7 +14,8 @@ import lj_union
 import hard_disk
 import hard_sphere
 
-subprojects = [alj_2d, lj_fluid, lj_union, hard_disk, hard_sphere]
+# subprojects = [alj_2d, lj_fluid, lj_union, hard_disk, hard_sphere]
+subprojects = [lj_union]
 
 project = signac.init_project(path=config.project_root)
 

--- a/hoomd_validation/init.py
+++ b/hoomd_validation/init.py
@@ -14,8 +14,7 @@ import lj_union
 import hard_disk
 import hard_sphere
 
-# subprojects = [alj_2d, lj_fluid, lj_union, hard_disk, hard_sphere]
-subprojects = [lj_union]
+subprojects = [alj_2d, lj_fluid, lj_union, hard_disk, hard_sphere]
 
 project = signac.init_project(path=config.project_root)
 

--- a/hoomd_validation/lj_union.py
+++ b/hoomd_validation/lj_union.py
@@ -23,7 +23,6 @@ TOTAL_STEPS = RANDOMIZE_STEPS + EQUILIBRATE_STEPS + RUN_STEPS
 
 WRITE_PERIOD = 4_000
 LOG_PERIOD = {'trajectory': 50_000, 'quantities': 100}
-# TODO: Increase r_cut?
 LJ_PARAMS = {'epsilon': 0.25, 'sigma': 1.0, 'r_on': 2.0, 'r_cut': 2.5}
 NUM_CPU_RANKS = min(8, CONFIG["max_cores_sim"])
 CUBE_VERTS = [

--- a/hoomd_validation/lj_union.py
+++ b/hoomd_validation/lj_union.py
@@ -1452,8 +1452,8 @@ def lj_union_conservation_analyze(*jobs):
             job_timesteps[sim_mode] = log_traj['configuration/step']
 
             job_energies[sim_mode] = (
-                log_traj['md/compute/ThermodynamicQuantities/potential_energy']
-                + log_traj['md/compute/ThermodynamicQuantities/kinetic_energy'])
+                log_traj['log/md/compute/ThermodynamicQuantities/potential_energy']
+                + log_traj['log/md/compute/ThermodynamicQuantities/kinetic_energy'])
             job_energies[sim_mode] = (
                 job_energies[sim_mode]
                 - job_energies[sim_mode][0]) / job.statepoint["num_particles"]

--- a/hoomd_validation/lj_union.py
+++ b/hoomd_validation/lj_union.py
@@ -10,16 +10,20 @@ import util
 import os
 import math
 import collections
+import json
+import pathlib
 
 # Run parameters shared between simulations.
 # Step counts must be even and a multiple of the log quantity period.
 RANDOMIZE_STEPS = 20_000
 EQUILIBRATE_STEPS = 100_000
-RUN_STEPS = 2_000_000
+RUN_STEPS = 500_000
+RESTART_STEPS = RUN_STEPS // 10
 TOTAL_STEPS = RANDOMIZE_STEPS + EQUILIBRATE_STEPS + RUN_STEPS
 
 WRITE_PERIOD = 4_000
-LOG_PERIOD = {'trajectory': 50_000, 'quantities': 4_000}
+LOG_PERIOD = {'trajectory': 50_000, 'quantities': 100}
+# TODO: Increase r_cut?
 LJ_PARAMS = {'epsilon': 0.25, 'sigma': 1.0, 'r_on': 2.0, 'r_cut': 2.5}
 NUM_CPU_RANKS = min(8, CONFIG["max_cores_sim"])
 CUBE_VERTS = [
@@ -32,6 +36,8 @@ CUBE_VERTS = [
     (0.5, 0.5, -0.5),
     (0.5, 0.5, 0.5),
 ]
+
+WALLTIME_STOP_SECONDS = CONFIG["max_walltime"] * 3600 - 10 * 60
 
 # Limit the number of long NVE runs to reduce the number of CPU hours needed.
 NUM_NVE_RUNS = 2
@@ -70,7 +76,6 @@ partition_jobs_gpu = aggregator.groupsof(num=min(CONFIG["replicates"],
                                          select=is_lj_union)
 
 
-@Project.post.isfile('lj_union_initial_state.gsd')
 @Project.post.isfile('lj_union_initial_state_md.gsd')
 @Project.operation(directives=dict(
     executable=CONFIG["executable"],
@@ -152,6 +157,10 @@ def lj_union_create_initial_state(*jobs):
     hoomd.write.GSD.write(state=sim.state,
                           filename=job.fn("lj_union_initial_state_md.gsd"),
                           mode='wb')
+
+    if communicator.rank == 0:
+        print(f'completed lj_union_create_initial_state: '
+              f'{job} in {communicator.walltime} s')
 
 
 #################################
@@ -261,7 +270,7 @@ def make_md_simulation(job,
     return sim
 
 
-def run_md_sim(job, device, ensemble, thermostat):
+def run_md_sim(job, device, ensemble, thermostat, complete_filename):
     """Run the MD simulation with the given ensemble and thermostat."""
     import hoomd
     from hoomd import md
@@ -291,8 +300,7 @@ def run_md_sim(job, device, ensemble, thermostat):
         method = md.methods.ConstantPressure(integrate_filter,
                                              S=[p, p, p, 0, 0, 0],
                                              tauS=3,
-                                             couple='xyz',
-                                             gamma=0.5)
+                                             couple='xyz')
         if thermostat == 'bussi':
             method.thermostat = hoomd.md.methods.thermostats.Bussi(
                 kT=job.statepoint.kT)
@@ -330,6 +338,8 @@ def run_md_sim(job, device, ensemble, thermostat):
     sim.run(RUN_STEPS)
     device.notice('Done.')
 
+    pathlib.Path(job.fn(complete_filename)).touch()
+
 
 md_sampling_jobs = []
 md_job_definitions = [
@@ -342,6 +352,30 @@ md_job_definitions = [
     },
     {
         'ensemble': 'nvt',
+        'thermostat': 'mttk',
+        'device_name': 'cpu',
+        'ranks_per_partition': NUM_CPU_RANKS,
+        'aggregator': partition_jobs_cpu_mpi
+    },
+    {
+        'ensemble': 'nvt',
+        'thermostat': 'bussi',
+        'device_name': 'cpu',
+        'ranks_per_partition': NUM_CPU_RANKS,
+        'aggregator': partition_jobs_cpu_mpi
+    },
+    {
+        'ensemble': 'npt',
+        'thermostat': 'bussi',
+        'device_name': 'cpu',
+        'ranks_per_partition': NUM_CPU_RANKS,
+        'aggregator': partition_jobs_cpu_mpi
+    },
+]
+
+if CONFIG["enable_gpu"]:
+    md_job_definitions.extend([    {
+        'ensemble': 'nvt',
         'thermostat': 'langevin',
         'device_name': 'gpu',
         'ranks_per_partition': 1,
@@ -350,23 +384,9 @@ md_job_definitions = [
     {
         'ensemble': 'nvt',
         'thermostat': 'mttk',
-        'device_name': 'cpu',
-        'ranks_per_partition': NUM_CPU_RANKS,
-        'aggregator': partition_jobs_cpu_mpi
-    },
-    {
-        'ensemble': 'nvt',
-        'thermostat': 'mttk',
         'device_name': 'gpu',
         'ranks_per_partition': 1,
         'aggregator': partition_jobs_gpu
-    },
-    {
-        'ensemble': 'nvt',
-        'thermostat': 'bussi',
-        'device_name': 'cpu',
-        'ranks_per_partition': NUM_CPU_RANKS,
-        'aggregator': partition_jobs_cpu_mpi
     },
     {
         'ensemble': 'nvt',
@@ -378,26 +398,18 @@ md_job_definitions = [
     {
         'ensemble': 'npt',
         'thermostat': 'bussi',
-        'device_name': 'cpu',
-        'ranks_per_partition': NUM_CPU_RANKS,
-        'aggregator': partition_jobs_cpu_mpi
-    },
-    {
-        'ensemble': 'npt',
-        'thermostat': 'bussi',
         'device_name': 'gpu',
         'ranks_per_partition': 1,
         'aggregator': partition_jobs_gpu
     },
-]
-
+    ])
 
 def add_md_sampling_job(ensemble, thermostat, device_name, ranks_per_partition,
                         aggregator):
     """Add a MD sampling job to the workflow."""
     sim_mode = f'{ensemble}_{thermostat}_md'
 
-    directives = dict(walltime=CONFIG["short_walltime"],
+    directives = dict(walltime=CONFIG["max_walltime"],
                       executable=CONFIG["executable"],
                       nranks=util.total_ranks_function(ranks_per_partition))
 
@@ -405,9 +417,7 @@ def add_md_sampling_job(ensemble, thermostat, device_name, ranks_per_partition,
         directives['ngpu'] = util.total_ranks_function(ranks_per_partition)
 
     @Project.pre.after(lj_union_create_initial_state)
-    @Project.post(
-        util.gsd_step_greater_equal_function(
-            f'{sim_mode}_{device_name}_quantities.gsd', TOTAL_STEPS))
+    @Project.post.isfile(f'{sim_mode}_{device_name}_complete')
     @Project.operation(name=f'lj_union_{sim_mode}_{device_name}',
                        directives=directives,
                        aggregator=aggregator)
@@ -420,7 +430,7 @@ def add_md_sampling_job(ensemble, thermostat, device_name, ranks_per_partition,
         job = jobs[communicator.partition]
 
         if communicator.rank == 0:
-            print(f'starting lj_union_{sim_mode}_{device_name}', job)
+            print(f'starting lj_union_{sim_mode}_{device_name}:', job)
 
         if device_name == 'gpu':
             device_cls = hoomd.device.GPU
@@ -429,9 +439,13 @@ def add_md_sampling_job(ensemble, thermostat, device_name, ranks_per_partition,
 
         device = device_cls(
             communicator=communicator,
-            message_filename=job.fn(f'run_{sim_mode}_{device_name}.log'))
+            message_filename=job.fn(f'{sim_mode}_{device_name}.log'))
 
-        run_md_sim(job, device, ensemble, thermostat)
+        run_md_sim(job, device, ensemble, thermostat, complete_filename=f'{sim_mode}_{device_name}_complete')
+
+        if communicator.rank == 0:
+            print(f'completed lj_union_{sim_mode}_{device_name}: '
+                  f'{job} in {communicator.walltime} s')
 
     md_sampling_jobs.append(md_sampling_operation)
 
@@ -462,6 +476,8 @@ def make_mc_simulation(job,
     """
     import hoomd
     from hoomd import hpmc
+    import numpy
+    from custom_actions import ComputeDensity
 
     # integrator
     mc = hpmc.integrate.Sphere(nselect=1)
@@ -490,9 +506,16 @@ def make_mc_simulation(job,
                 float r12inv = r6inv * r6inv;
                 float energy = 4 * {epsilon} * (r12inv - r6inv);
 
-                // apply xplor smoothing
                 float r_on = {r_on};
                 float r_onsq = r_on * r_on;
+
+                // energy shift for WCA
+                if (r_onsq > r_cutsq)
+                {{
+                    energy += {epsilon};
+                }}
+
+                // apply xplor smoothing
                 if (rsq > r_onsq)
                 {{
                     // computing denominator for the shifting factor
@@ -537,10 +560,16 @@ def make_mc_simulation(job,
     lj_jit_potential.charges['R'] = [0] * len(CUBE_VERTS)
     mc.pair_potential = lj_jit_potential
 
+    # Note: Computing the virial pressure is non-trivial, skip
+
+    # compute the density
+    compute_density = ComputeDensity()
+
     # log to gsd
     logger_gsd = hoomd.logging.Logger(categories=['scalar', 'sequence'])
     logger_gsd.add(lj_jit_potential, quantities=['energy'])
     logger_gsd.add(mc, quantities=['translate_moves', 'rotate_moves'])
+    logger_gsd.add(compute_density)
     for loggable in extra_loggables:
         logger_gsd.add(loggable)
 
@@ -562,6 +591,8 @@ def make_mc_simulation(job,
         if hasattr(loggable, 'attach'):
             loggable.attach(sim)
 
+    compute_density.attach(sim)
+
     # move size tuner
     mstuner = hpmc.tune.MoveSize.scale_solver(
         moves=['a', 'd'],
@@ -578,7 +609,7 @@ def make_mc_simulation(job,
     return sim
 
 
-def run_nvt_mc_sim(job, device):
+def run_nvt_mc_sim(job, device, complete_filename):
     """Run MC sim in NVT."""
     import hoomd
 
@@ -587,51 +618,94 @@ def run_nvt_mc_sim(job, device):
         return
 
     # simulation
-    initial_state = job.fn('lj_union_initial_state.gsd')
+
     sim_mode = 'nvt_mc'
+    restart_filename = util.get_job_filename(sim_mode, device, 'restart', 'gsd')
+    if job.isfile(restart_filename):
+        initial_state = job.fn(restart_filename)
+        restart = True
+    else:
+        initial_state = job.fn('lj_union_initial_state.gsd')
+        restart = False
+
     sim = make_mc_simulation(job, device, initial_state, sim_mode)
 
-    # equilibrate
-    device.notice('Equilibrating...')
-    sim.run(EQUILIBRATE_STEPS // 2)
-    sim.run(EQUILIBRATE_STEPS // 2)
-    device.notice('Done.')
+    if not restart:
+        # equilibrate
+        device.notice('Equilibrating...')
+        sim.run(EQUILIBRATE_STEPS // 2)
+        sim.run(EQUILIBRATE_STEPS // 2)
+        device.notice('Done.')
 
-    # Print acceptance ratio as measured during the 2nd half of the
-    # equilibration.
-    translate_moves = sim.operations.integrator.translate_moves
-    translate_acceptance = translate_moves[0] / sum(translate_moves)
-    device.notice(f'Translate move acceptance: {translate_acceptance}')
-    device.notice(
-        f'Translate trial move size: {sim.operations.integrator.d["R"]}')
+        # Print acceptance ratio as measured during the 2nd half of the
+        # equilibration.
+        translate_moves = sim.operations.integrator.translate_moves
+        translate_acceptance = translate_moves[0] / sum(translate_moves)
+        device.notice(f'Translate move acceptance: {translate_acceptance}')
+        device.notice(
+            f'Translate trial move size: {sim.operations.integrator.d["R"]}')
 
-    rotate_moves = sim.operations.integrator.rotate_moves
-    rotate_acceptance = rotate_moves[0] / sum(rotate_moves)
-    device.notice(f'Rotate move acceptance: {rotate_acceptance}')
-    device.notice(f'Rotate trial move size: {sim.operations.integrator.a["R"]}')
+        rotate_moves = sim.operations.integrator.rotate_moves
+        rotate_acceptance = rotate_moves[0] / sum(rotate_moves)
+        device.notice(f'Rotate move acceptance: {rotate_acceptance}')
+        device.notice(f'Rotate trial move size: {sim.operations.integrator.a["R"]}')
+
+        # save move size to a file
+        if device.communicator.rank == 0:
+            name = util.get_job_filename(sim_mode, device, 'move_size', 'json')
+            with open(job.fn(name), 'w') as f:
+                json.dump(dict(d_R=sim.operations.integrator.d["R"], a_R=sim.operations.integrator.a["R"],), f)
+    else:
+        device.notice('Restarting...')
+        # read move size from the file
+        name = util.get_job_filename(sim_mode, device, 'move_size', 'json')
+        with open(job.fn(name), 'r') as f:
+            data = json.load(f)
+
+        sim.operations.integrator.d["R"] = data['d_R']
+        sim.operations.integrator.a["R"] = data['a_R']
+        device.notice(
+            f'Restored translate move size: {sim.operations.integrator.d["R"]}')
+        device.notice(
+            f'Restored rotate move size: {sim.operations.integrator.a["R"]}')
 
     # run
     device.notice('Running...')
-    sim.run(RUN_STEPS)
-    device.notice('Done.')
+    util.run_up_to_walltime(sim=sim,
+                            end_step=TOTAL_STEPS,
+                            steps=RESTART_STEPS,
+                            walltime_stop=WALLTIME_STOP_SECONDS)
+
+    hoomd.write.GSD.write(state=sim.state,
+                          filename=job.fn(restart_filename),
+                          mode='wb')
+
+    if sim.timestep == TOTAL_STEPS:
+        pathlib.Path(job.fn(complete_filename)).touch()
+        device.notice('Done.')
+    else:
+        device.notice('Ending run early due to walltime limits at:'
+                      f'{device.communicator.walltime}')
 
 
-def run_npt_mc_sim(job, device):
+def run_npt_mc_sim(job, device, complete_filename):
     """Run MC sim in NPT."""
     import hoomd
     from hoomd import hpmc
-    from custom_actions import ComputeDensity
 
     if not hoomd.version.llvm_enabled:
         device.notice("LLVM disabled, skipping MC simulations.")
         return
 
-    # device
-    initial_state = job.fn('lj_union_initial_state.gsd')
     sim_mode = 'npt_mc'
 
-    # compute the density
-    compute_density = ComputeDensity(job.statepoint['num_particles'])
+    restart_filename = util.get_job_filename(sim_mode, device, 'restart', 'gsd')
+    if job.isfile(restart_filename):
+        initial_state = job.fn(restart_filename)
+        restart = True
+    else:
+        initial_state = job.fn('lj_union_initial_state.gsd')
+        restart = False
 
     # box updates
     boxmc = hpmc.update.BoxMC(betaP=job.statepoint.pressure / job.sp.kT,
@@ -643,7 +717,7 @@ def run_npt_mc_sim(job, device):
                              device,
                              initial_state,
                              sim_mode,
-                             extra_loggables=[compute_density, boxmc])
+                             extra_loggables=[boxmc])
 
     sim.operations.add(boxmc)
 
@@ -657,34 +731,72 @@ def run_npt_mc_sim(job, device):
         target=0.5)
     sim.operations.add(boxmc_tuner)
 
-    # equilibrate
-    device.notice('Equilibrating...')
-    sim.run(EQUILIBRATE_STEPS // 2)
-    sim.run(EQUILIBRATE_STEPS // 2)
-    device.notice('Done.')
+    if not restart:
+        # equilibrate
+        device.notice('Equilibrating...')
+        sim.run(EQUILIBRATE_STEPS // 2)
+        sim.run(EQUILIBRATE_STEPS // 2)
+        device.notice('Done.')
 
-    # Print acceptance ratio as measured during the 2nd half of the
-    # equilibration.
-    translate_moves = sim.operations.integrator.translate_moves
-    translate_acceptance = translate_moves[0] / sum(translate_moves)
-    device.notice(f'Translate move acceptance: {translate_acceptance}')
-    device.notice(
-        f'Translate trial move size: {sim.operations.integrator.d["R"]}')
+        # Print acceptance ratio as measured during the 2nd half of the
+        # equilibration.
+        translate_moves = sim.operations.integrator.translate_moves
+        translate_acceptance = translate_moves[0] / sum(translate_moves)
+        device.notice(f'Translate move acceptance: {translate_acceptance}')
+        device.notice(
+            f'Translate trial move size: {sim.operations.integrator.d["R"]}')
 
-    rotate_moves = sim.operations.integrator.rotate_moves
-    rotate_acceptance = rotate_moves[0] / sum(rotate_moves)
-    device.notice(f'Rotate move acceptance: {rotate_acceptance}')
-    device.notice(f'Rotate trial move size: {sim.operations.integrator.a["R"]}')
+        rotate_moves = sim.operations.integrator.rotate_moves
+        rotate_acceptance = rotate_moves[0] / sum(rotate_moves)
+        device.notice(f'Rotate move acceptance: {rotate_acceptance}')
+        device.notice(f'Rotate trial move size: {sim.operations.integrator.a["R"]}')
 
-    volume_moves = boxmc.volume_moves
-    volume_acceptance = volume_moves[0] / sum(volume_moves)
-    device.notice(f'Volume move acceptance: {volume_acceptance}')
-    device.notice(f'Volume move size: {boxmc.volume["delta"]}')
+        volume_moves = boxmc.volume_moves
+        volume_acceptance = volume_moves[0] / sum(volume_moves)
+        device.notice(f'Volume move acceptance: {volume_acceptance}')
+        device.notice(f'Volume move size: {boxmc.volume["delta"]}')
+
+        # save move sizes to a file
+        if device.communicator.rank == 0:
+            name = util.get_job_filename(sim_mode, device, 'move_size', 'json')
+            with open(job.fn(name), 'w') as f:
+                json.dump(
+                    dict(d_R=sim.operations.integrator.d["R"],
+                         a_R=sim.operations.integrator.a["R"],
+                         volume_delta=boxmc.volume['delta']), f)
+    else:
+        device.notice('Restarting...')
+        # read move size from the file
+        name = util.get_job_filename(sim_mode, device, 'move_size', 'json')
+        with open(job.fn(name), 'r') as f:
+            data = json.load(f)
+
+        sim.operations.integrator.d["R"] = data['d_R']
+        sim.operations.integrator.a["R"] = data['a_R']
+        device.notice(
+            f'Restored translate move size: {sim.operations.integrator.d["R"]}')
+        device.notice(
+            f'Restored rotate move size: {sim.operations.integrator.a["R"]}')
+        boxmc.volume = dict(weight=1.0, mode='ln', delta=data['volume_delta'])
+        device.notice(f'Resotred volume move size: {boxmc.volume["delta"]}')
 
     # run
     device.notice('Running...')
-    sim.run(RUN_STEPS)
-    device.notice('Done.')
+    util.run_up_to_walltime(sim=sim,
+                            end_step=TOTAL_STEPS,
+                            steps=RESTART_STEPS,
+                            walltime_stop=WALLTIME_STOP_SECONDS)
+
+    hoomd.write.GSD.write(state=sim.state,
+                          filename=job.fn(restart_filename),
+                          mode='wb')
+
+    if sim.timestep == TOTAL_STEPS:
+        pathlib.Path(job.fn(complete_filename)).touch()
+        device.notice('Done.')
+    else:
+        device.notice('Ending run early due to walltime limits at:'
+                      f'{device.communicator.walltime}')
 
 
 mc_sampling_jobs = []
@@ -696,12 +808,6 @@ mc_job_definitions = [
         'aggregator': partition_jobs_cpu_mpi
     },
     {
-        'mode': 'nvt',
-        'device_name': 'gpu',
-        'ranks_per_partition': 1,
-        'aggregator': partition_jobs_gpu
-    },
-    {
         'mode': 'npt',
         'device_name': 'cpu',
         'ranks_per_partition': NUM_CPU_RANKS,
@@ -709,10 +815,19 @@ mc_job_definitions = [
     },
 ]
 
+if CONFIG["enable_gpu"]:
+    mc_job_definitions.extend([    {
+        'mode': 'nvt',
+        'device_name': 'gpu',
+        'ranks_per_partition': 1,
+        'aggregator': partition_jobs_gpu
+    },
+    ])
+
 
 def add_mc_sampling_job(mode, device_name, ranks_per_partition, aggregator):
     """Add a MC sampling job to the workflow."""
-    directives = dict(walltime=CONFIG["short_walltime"],
+    directives = dict(walltime=CONFIG["max_walltime"],
                       executable=CONFIG["executable"],
                       nranks=util.total_ranks_function(ranks_per_partition))
 
@@ -720,9 +835,7 @@ def add_mc_sampling_job(mode, device_name, ranks_per_partition, aggregator):
         directives['ngpu'] = util.total_ranks_function(ranks_per_partition)
 
     @Project.pre.after(lj_union_create_initial_state)
-    @Project.post(
-        util.gsd_step_greater_equal_function(
-            f'{mode}_mc_{device_name}_quantities.gsd', TOTAL_STEPS))
+    @Project.post.isfile(f'{mode}_mc_{device_name}_complete')
     @Project.operation(name=f'lj_union_{mode}_mc_{device_name}',
                        directives=directives,
                        aggregator=aggregator)
@@ -735,7 +848,7 @@ def add_mc_sampling_job(mode, device_name, ranks_per_partition, aggregator):
         job = jobs[communicator.partition]
 
         if communicator.rank == 0:
-            print(f'starting lj_union_{mode}_mc_{device_name}', job)
+            print(f'starting lj_union_{mode}_mc_{device_name}:', job)
 
         if device_name == 'gpu':
             device_cls = hoomd.device.GPU
@@ -744,9 +857,13 @@ def add_mc_sampling_job(mode, device_name, ranks_per_partition, aggregator):
 
         device = device_cls(
             communicator=communicator,
-            message_filename=job.fn(f'run_{mode}_mc_{device_name}.log'))
+            message_filename=job.fn(f'{mode}_mc_{device_name}.log'))
 
-        globals().get(f'run_{mode}_mc_sim')(job, device)
+        globals().get(f'run_{mode}_mc_sim')(job, device, complete_filename=f'{mode}_mc_{device_name}_complete')
+
+        if communicator.rank == 0:
+            print(f'completed lj_union_{mode}_mc_{device_name} '
+                  f'{job} in {communicator.walltime} s')
 
     mc_sampling_jobs.append(sampling_operation)
 
@@ -770,89 +887,65 @@ def lj_union_analyze(job):
     import matplotlib
     import matplotlib.style
     import matplotlib.figure
-    matplotlib.style.use('ggplot')
-    from util import read_gsd_log_trajectory, get_log_quantity
+    matplotlib.style.use('fivethirtyeight')
 
     print('starting lj_union_analyze:', job)
 
-    constant = dict(
-        nvt_langevin_md_cpu='density',
-        nvt_langevin_md_gpu='density',
-        nvt_mttk_md_cpu='density',
-        nvt_mttk_md_gpu='density',
-        nvt_bussi_md_cpu='density',
-        nvt_bussi_md_gpu='density',
-        nvt_mc_cpu='density',
-        nvt_mc_gpu='density',
-        npt_bussi_md_cpu='pressure',
-        npt_bussi_md_gpu='pressure',
-        npt_mc_cpu='pressure',
-        npt_mc_gpu='pressure',
-    )
     sim_modes = [
         'nvt_langevin_md_cpu',
-        'nvt_langevin_md_gpu',
         'nvt_mttk_md_cpu',
-        'nvt_mttk_md_gpu',
         'nvt_bussi_md_cpu',
-        'nvt_bussi_md_gpu',
         'npt_bussi_md_cpu',
-        'npt_bussi_md_gpu',
     ]
 
-    if os.path.exists(job.fn('nvt_mc_cpu_quantities.gsd')):
-        sim_modes.extend(['nvt_mc_cpu', 'nvt_mc_gpu', 'npt_mc_cpu'])
+    if os.path.exists(job.fn('nvt_langevin_md_gpu_quantities.gsd')):
+        sim_modes.extend([
+            'nvt_langevin_md_gpu',
+            'nvt_mttk_md_gpu',
+            'nvt_bussi_md_gpu',
+            'npt_bussi_md_gpu',
+        ])
 
+    if os.path.exists(job.fn('nvt_mc_cpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_cpu', 'npt_mc_cpu'])
+
+    if os.path.exists(job.fn('nvt_mc_gpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_gpu'])
+
+    util._sort_sim_modes(sim_modes)
+
+    timesteps = {}
     energies = {}
     pressures = {}
     densities = {}
     linear_momentum = {}
-    kinetic_temperature = {}
 
     for sim_mode in sim_modes:
-        with gsd.hoomd.open(job.fn(sim_mode + '_quantities.gsd')) as gsd_traj:
-            # read GSD file once
-            traj = read_gsd_log_trajectory(gsd_traj)
+        log_traj = gsd.hoomd.read_log(job.fn(sim_mode + '_quantities.gsd'))
+
+        timesteps[sim_mode] = log_traj['configuration/step']
 
         if 'md' in sim_mode:
-            energies[sim_mode] = get_log_quantity(
-                traj, 'md/compute/ThermodynamicQuantities/potential_energy')
+            energies[sim_mode] = log_traj['log/md/compute/ThermodynamicQuantities/potential_energy']
         else:
-            energies[sim_mode] = numpy.array(
-                get_log_quantity(traj, 'hpmc/pair/user/CPPPotentialUnion/energy'
-                                 )) * job.statepoint.kT
+            energies[sim_mode] = log_traj['log/hpmc/pair/user/CPPPotentialUnion/energy'] * job.statepoint.kT
 
-        if constant[sim_mode] == 'density' and 'md' in sim_mode:
-            pressures[sim_mode] = get_log_quantity(
-                traj, 'md/compute/ThermodynamicQuantities/pressure')
-        elif constant[sim_mode] == 'density' and 'mc' in sim_mode:
+        energies[sim_mode] /= job.statepoint.num_particles
+
+        if 'md' in sim_mode:
+            pressures[sim_mode] = log_traj['log/md/compute/ThermodynamicQuantities/pressure']
+        else:
             pressures[sim_mode] = numpy.full(len(energies[sim_mode]), numpy.nan)
-        else:
-            pressures[sim_mode] = numpy.ones(len(
-                energies[sim_mode])) * job.statepoint.pressure
 
-        if constant[sim_mode] == 'pressure':
-            densities[sim_mode] = get_log_quantity(
-                traj, 'custom_actions/ComputeDensity/density')
-        else:
-            densities[sim_mode] = numpy.ones(len(
-                energies[sim_mode])) * job.statepoint.density
+        densities[sim_mode] = log_traj['log/custom_actions/ComputeDensity/density']
 
         if 'md' in sim_mode and 'langevin' not in sim_mode:
-            momentum_vector = get_log_quantity(traj,
-                                               'md/Integrator/linear_momentum')
+            momentum_vector = log_traj['log/md/Integrator/linear_momentum']
             linear_momentum[sim_mode] = [
                 math.sqrt(v[0]**2 + v[1]**2 + v[2]**2) for v in momentum_vector
             ]
         else:
             linear_momentum[sim_mode] = numpy.zeros(len(energies[sim_mode]))
-
-        if 'md' in sim_mode:
-            kinetic_temperature[sim_mode] = get_log_quantity(
-                traj, 'md/compute/ThermodynamicQuantities/kinetic_temperature')
-        else:
-            kinetic_temperature[sim_mode] = numpy.ones(len(
-                energies[sim_mode])) * job.statepoint.kT
 
     # save averages
     for mode in sim_modes:
@@ -861,100 +954,40 @@ def lj_union_analyze(job):
                                       numpy.mean(energies[mode])),
                                   density=float(numpy.mean(densities[mode])))
 
-    # Plot results
-    def plot(*, ax, data, quantity_name, base_line=None, legend=False):
-        for mode in sim_modes:
-            ax.plot(numpy.asarray(data[mode]), label=mode)
-        ax.set_xlabel("frame")
-        ax.set_ylabel(quantity_name)
-        if base_line is not None:
-            ax.hlines(y=base_line,
-                      xmin=0,
-                      xmax=len(data[sim_modes[0]]),
-                      linestyles='dashed',
-                      colors='k')
-
-        if legend:
-            ax.legend()
-
     fig = matplotlib.figure.Figure(figsize=(20, 20 / 3.24 * 2), layout='tight')
-    ax = fig.add_subplot(3, 2, 1)
-    plot(ax=ax,
-         data=densities,
-         quantity_name=r"$\rho$",
-         base_line=job.sp.density,
-         legend=True)
+    ax = fig.add_subplot(2, 2, 1)
+    util.plot_timeseries(ax=ax,
+                         timesteps=timesteps,
+                         data=densities,
+                         ylabel=r"$\rho$",
+                         expected=job.sp.density,
+                         max_points=500)
+    ax.legend()
 
-    ax = fig.add_subplot(3, 2, 2)
-    plot(ax=ax, data=pressures, quantity_name=r"$P$", base_line=job.sp.pressure)
+    ax = fig.add_subplot(2, 2, 2)
+    util.plot_timeseries(ax=ax,
+                         timesteps=timesteps,
+                         data=pressures,
+                         ylabel=r"$P$",
+                         expected=job.sp.pressure,
+                         max_points=500)
 
-    ax = fig.add_subplot(3, 2, 3)
-    plot(ax=ax, data=energies, quantity_name="$U / N$")
+    ax = fig.add_subplot(2, 2, 3)
+    util.plot_timeseries(ax=ax,
+                         timesteps=timesteps,
+                         data=energies,
+                         ylabel="$U / N$",
+                         max_points=500)
 
-    ax = fig.add_subplot(3, 2, 4)
-    plot(ax=ax,
-         data=kinetic_temperature,
-         quantity_name='kinetic temperature',
-         base_line=job.sp.kT)
-
-    ax = fig.add_subplot(3, 2, 5)
-    plot(ax=ax,
-         data={
-             mode: numpy.asarray(lm) / job.sp.num_particles
-             for mode, lm in linear_momentum.items()
-         },
-         quantity_name=r'$|\vec{p}| / N$')
-
-    # determine range for density and pressure histograms
-    density_range = [
-        numpy.min(densities[sim_modes[0]]),
-        numpy.max(densities[sim_modes[0]])
-    ]
-    pressure_range = [
-        numpy.min(pressures[sim_modes[0]]),
-        numpy.max(pressures[sim_modes[0]])
-    ]
-
-    for mode in sim_modes[1:]:
-        density_range[0] = min(density_range[0], numpy.min(densities[mode]))
-        density_range[1] = max(density_range[1], numpy.max(densities[mode]))
-        pressure_range[0] = min(pressure_range[0], numpy.min(pressures[mode]))
-        pressure_range[1] = max(pressure_range[1], numpy.max(pressures[mode]))
-
-    def plot_histo(*, ax, data, quantity_name, sp_name, range):
-        max_density_histogram = 0
-        for mode in sim_modes:
-            histogram, bin_edges = numpy.histogram(data[mode],
-                                                   bins=50,
-                                                   range=range)
-            if constant[mode] == sp_name:
-                histogram[:] = 0
-
-            max_density_histogram = max(max_density_histogram,
-                                        numpy.max(histogram))
-
-            ax.plot(bin_edges[:-1], histogram, label=mode)
-        ax.set_xlabel(quantity_name)
-        ax.set_ylabel('frequency')
-        ax.vlines(x=job.sp[sp_name],
-                  ymin=0,
-                  ymax=max_density_histogram,
-                  linestyles='dashed',
-                  colors='k')
-
-    ax = fig.add_subplot(3, 4, 11)
-    plot_histo(ax=ax,
-               data=densities,
-               quantity_name=r"$\rho$",
-               sp_name="density",
-               range=density_range)
-
-    ax = fig.add_subplot(3, 4, 12)
-    plot_histo(ax=ax,
-               data=pressures,
-               quantity_name="$P$",
-               sp_name="pressure",
-               range=pressure_range)
+    ax = fig.add_subplot(2, 2, 4)
+    util.plot_timeseries(ax=ax,
+                         timesteps=timesteps,
+                         data={
+                             mode: numpy.asarray(lm) / job.sp.num_particles
+                             for mode, lm in linear_momentum.items()
+                         },
+                         ylabel=r'$|\vec{p}| / N$',
+                         max_points=500)
 
     fig.suptitle(f"$kT={job.statepoint.kT}$, $\\rho={job.statepoint.density}$, "
                  f"$N={job.statepoint.num_particles}$, "
@@ -982,26 +1015,40 @@ def lj_union_compare_modes(*jobs):
     import matplotlib
     import matplotlib.style
     import matplotlib.figure
-    import scipy.stats
-    matplotlib.style.use('ggplot')
+    matplotlib.style.use('fivethirtyeight')
 
     print('starting lj_union_compare_modes:', jobs[0])
 
     sim_modes = [
         'nvt_langevin_md_cpu',
-        'nvt_langevin_md_gpu',
         'nvt_mttk_md_cpu',
-        'nvt_mttk_md_gpu',
         'nvt_bussi_md_cpu',
-        'nvt_bussi_md_gpu',
         'npt_bussi_md_cpu',
-        'npt_bussi_md_gpu',
     ]
 
+    if os.path.exists(jobs[0].fn('nvt_langevin_md_gpu_quantities.gsd')):
+        sim_modes.extend([
+            'nvt_langevin_md_gpu',
+            'nvt_mttk_md_gpu',
+            'nvt_bussi_md_gpu',
+            'npt_bussi_md_gpu',
+        ])
+
     if os.path.exists(jobs[0].fn('nvt_mc_cpu_quantities.gsd')):
-        sim_modes.extend(['nvt_mc_cpu', 'nvt_mc_gpu', 'npt_mc_cpu'])
+        sim_modes.extend(['nvt_mc_cpu', 'npt_mc_cpu'])
+
+    if os.path.exists(jobs[0].fn('nvt_mc_gpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_gpu'])
+
+    util._sort_sim_modes(sim_modes)
 
     quantity_names = ['density', 'pressure', 'potential_energy']
+
+    labels = {
+        'density': r'$\frac{\rho_\mathrm{sample} - \rho}{\rho} \cdot 1000$',
+        'pressure': r'$\frac{P_\mathrm{sample} - P}{P} \cdot 1000$',
+        'potential_energy': r'$\frac{U_\mathrm{sample} - <U>}{<U>} \cdot 1000$',
+    }
 
     # grab the common statepoint parameters
     kT = jobs[0].sp.kT
@@ -1026,53 +1073,29 @@ def lj_union_compare_modes(*jobs):
                 quantities[mode].append(
                     getattr(getattr(jb.doc, mode), quantity_name))
 
-        # compute stats with data
-        avg_quantity = {
-            mode: numpy.mean(quantities[mode]) for mode in sim_modes
-        }
-        stderr_quantity = {
-            mode:
-            2 * numpy.std(quantities[mode]) / numpy.sqrt(len(quantities[mode]))
-            for mode in sim_modes
-        }
-
-        # compute the energy differences
-        quantity_list = [avg_quantity[mode] for mode in sim_modes]
-        stderr_list = numpy.array([stderr_quantity[mode] for mode in sim_modes])
-
         if quantity_reference[quantity_name] is not None:
             reference = quantity_reference[quantity_name]
         else:
-            reference = numpy.mean(quantity_list)
+            avg_value = {
+                mode: numpy.mean(quantities[mode]) for mode in sim_modes
+            }
+            reference = numpy.mean([avg_value[mode] for mode in sim_modes])
 
-        quantity_diff_list = numpy.array(quantity_list) - reference
+        avg_quantity, stderr_quantity = util.plot_vs_expected(
+            ax=ax,
+            values=quantities,
+            ylabel=labels[quantity_name],
+            expected=reference,
+            relative_scale=1000,
+            separate_nvt_npt=True)
 
-        ax.errorbar(x=range(len(sim_modes)),
-                    y=quantity_diff_list / reference / 1e-3,
-                    yerr=numpy.fabs(stderr_list / reference / 1e-3),
-                    fmt='s')
-        ax.set_xticks(range(len(sim_modes)), sim_modes, rotation=45)
-        ax.set_ylabel(quantity_name + ' relative error / 1e-3')
-        ax.hlines(y=0,
-                  xmin=0,
-                  xmax=len(sim_modes) - 1,
-                  linestyles='dashed',
-                  colors='k')
-
-        # Remove nan values, then run ANOVA test
-        if quantity_name == 'pressure' and 'nvt_mc_cpu' in quantities:
-            del quantities['nvt_mc_cpu']
-        if quantity_name == 'pressure' and 'nvt_mc_gpu' in quantities:
-            del quantities['nvt_mc_gpu']
-        unpacked_quantities = list(quantities.values())
-        f, p = scipy.stats.f_oneway(*unpacked_quantities)
-
-        if p > 0.05:
-            result = r"$\checkmark$"
-        else:
-            result = "XX"
-
-        ax.set_title(label=result + f' ANOVA p-value: {p:0.3f}')
+        if quantity_name == "density":
+            print(f"Average npt_mc_cpu density {num_particles}:",
+                  avg_quantity['npt_mc_cpu'], '+/-',
+                  stderr_quantity['npt_mc_cpu'])
+            print(f"Average npt_md_cpu density {num_particles}:",
+                  avg_quantity['npt_bussi_md_cpu'], '+/-',
+                  stderr_quantity['npt_bussi_md_cpu'])
 
     filename = f'lj_union_compare_kT{kT}_density{round(set_density, 2)}.svg'
     fig.savefig(os.path.join(jobs[0]._project.path, filename),
@@ -1082,161 +1105,170 @@ def lj_union_compare_modes(*jobs):
         job.document['lj_union_compare_modes_complete'] = True
 
 
-@Project.pre(
-    util.gsd_step_greater_equal_function('nvt_langevin_md_cpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('nvt_langevin_md_gpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('nvt_mttk_md_cpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('nvt_mttk_md_gpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('nvt_bussi_md_cpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('nvt_bussi_md_gpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('npt_bussi_md_cpu_quantities.gsd',
-                                         TOTAL_STEPS))
-@Project.pre(
-    util.gsd_step_greater_equal_function('npt_bussi_md_gpu_quantities.gsd',
-                                         TOTAL_STEPS))
+@Project.pre.after(*md_sampling_jobs)
 @Project.post(
-    lambda *jobs: util.true_all(*jobs, key='lj_union_ke_analyze_complete'))
+    lambda *jobs: util.true_all(*jobs, key='lj_union_distribution_analyze_complete'))
 @Project.operation(directives=dict(walltime=CONFIG['short_walltime'],
                                    executable=CONFIG["executable"]),
                    aggregator=analysis_aggregator)
-def lj_union_ke_analyze(*jobs):
+def lj_union_distribution_analyze(*jobs):
     """Checks that MD follows the correct KE distribution."""
     import gsd.hoomd
     import numpy
     import matplotlib
     import matplotlib.style
     import matplotlib.figure
-    import util
-    matplotlib.style.use('ggplot')
+    import scipy
+    matplotlib.style.use('fivethirtyeight')
 
-    print('starting lj_union_ke_analyze:', jobs[0])
+    print('starting lj_union_distribution_analyze:', jobs[0])
 
     sim_modes = [
         'nvt_langevin_md_cpu',
-        'nvt_langevin_md_gpu',
         'nvt_mttk_md_cpu',
-        'nvt_mttk_md_gpu',
         'nvt_bussi_md_cpu',
-        'nvt_bussi_md_gpu',
         'npt_bussi_md_cpu',
-        'npt_bussi_md_gpu',
     ]
+
+    if os.path.exists(jobs[0].fn('nvt_langevin_md_gpu_quantities.gsd')):
+        sim_modes.extend([
+            'nvt_langevin_md_gpu',
+            'nvt_mttk_md_gpu',
+            'nvt_bussi_md_gpu',
+            'npt_bussi_md_gpu',
+        ])
+
+    if os.path.exists(jobs[0].fn('nvt_mc_cpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_cpu', 'npt_mc_cpu'])
+
+    if os.path.exists(jobs[0].fn('nvt_mc_gpu_quantities.gsd')):
+        sim_modes.extend(['nvt_mc_gpu'])
+
+    util._sort_sim_modes(sim_modes)
 
     # grab the common statepoint parameters
     kT = jobs[0].sp.kT
     set_density = jobs[0].sp.density
     num_particles = jobs[0].sp.num_particles
 
-    fig = matplotlib.figure.Figure(figsize=(10, 10 / 1.618 * 2), layout='tight')
+    fig = matplotlib.figure.Figure(figsize=(20, 20 / 3.24 * 4), layout='tight')
     fig.suptitle(f"$kT={kT}$, $\\rho={set_density}$, $N={num_particles}$")
 
-    n_dof_translate = num_particles * 3 - 3
-    n_dof_rotate = num_particles * 3
-    n_dof_total = num_particles * 6 - 3
+    # n_dof_translate = num_particles * 3 - 3
+    # n_dof_rotate = num_particles * 3
+    # n_dof_total = num_particles * 6 - 3
 
-    ke_translate_means = collections.defaultdict(list)
-    ke_translate_sigmas = collections.defaultdict(list)
-    ke_rotate_means = collections.defaultdict(list)
-    ke_rotate_sigmas = collections.defaultdict(list)
-    ke_total_means = collections.defaultdict(list)
-    ke_total_sigmas = collections.defaultdict(list)
+    ke_translate_means_expected = collections.defaultdict(list)
+    ke_translate_sigmas_expected = collections.defaultdict(list)
+    ke_translate_samples = collections.defaultdict(list)
+
+    ke_rotate_means_expected = collections.defaultdict(list)
+    ke_rotate_sigmas_expected = collections.defaultdict(list)
+    ke_rotate_samples = collections.defaultdict(list)
+
+    potential_energy_samples = collections.defaultdict(list)
+    pressure_samples = collections.defaultdict(list)
+    density_samples = collections.defaultdict(list)
 
     for job in jobs:
         for sim_mode in sim_modes:
-            with gsd.hoomd.open(job.fn(sim_mode
-                                       + '_quantities.gsd')) as gsd_traj:
-                traj = util.read_gsd_log_trajectory(gsd_traj)
+            if sim_mode.startswith('nvt_langevin'):
+                n_translate_dof = num_particles * 3
+            else:
+                n_translate_dof = num_particles * 3 - 3
 
-                ke = util.get_log_quantity(
-                    traj, 'md/compute/ThermodynamicQuantities/'
-                    'translational_kinetic_energy')
-                ke_translate_means[sim_mode].append(numpy.mean(ke))
-                ke_translate_sigmas[sim_mode].append(numpy.std(ke))
+            n_rotate_dof = num_particles * 3
 
-                ke = util.get_log_quantity(
-                    traj, 'md/compute/ThermodynamicQuantities/'
-                    'rotational_kinetic_energy')
-                ke_rotate_means[sim_mode].append(numpy.mean(ke))
-                ke_rotate_sigmas[sim_mode].append(numpy.std(ke))
+            print('Reading' + job.fn(sim_mode + '_quantities.gsd'))
+            log_traj = gsd.hoomd.read_log(job.fn(sim_mode + '_quantities.gsd'))
 
-                ke = util.get_log_quantity(
-                    traj, 'md/compute/ThermodynamicQuantities/kinetic_energy')
-                ke_total_means[sim_mode].append(numpy.mean(ke))
-                ke_total_sigmas[sim_mode].append(numpy.std(ke))
+            if 'md' in sim_mode:
+                # https://doi.org/10.1371/journal.pone.0202764
+                ke_translate = log_traj[
+                    'log/md/compute/ThermodynamicQuantities/translational_kinetic_energy']
+                ke_translate_means_expected[sim_mode].append(
+                    numpy.mean(ke_translate) - 1 / 2 * n_translate_dof * kT)
+                ke_translate_sigmas_expected[sim_mode].append(
+                    numpy.std(ke_translate) - 1 / math.sqrt(2) * math.sqrt(n_translate_dof) * kT)
+                ke_translate_samples[sim_mode].extend(ke_translate)
 
-    def plot_vs_expected(ax, values, expected, name):
-        # compute stats with data
-        avg_value = {mode: numpy.mean(values[mode]) for mode in sim_modes}
-        stderr_value = {
-            mode: 2 * numpy.std(values[mode]) / numpy.sqrt(len(values[mode]))
-            for mode in sim_modes
-        }
+                ke_rotate = log_traj[
+                    'log/md/compute/ThermodynamicQuantities/rotational_kinetic_energy']
+                ke_rotate_means_expected[sim_mode].append(
+                    numpy.mean(ke_rotate) - 1 / 2 * n_rotate_dof * kT)
+                ke_rotate_sigmas_expected[sim_mode].append(
+                    numpy.std(ke_rotate) - 1 / math.sqrt(2) * math.sqrt(n_rotate_dof) * kT)
+                ke_rotate_samples[sim_mode].extend(ke_rotate)
+            else:
+                ke_translate_samples[sim_mode].extend(
+                    [3 / 2 * job.statepoint.num_particles * job.statepoint.kT])
+                ke_rotate_samples[sim_mode].extend(
+                    [3 / 2 * job.statepoint.num_particles * job.statepoint.kT])
 
-        # compute the energy differences
-        value_list = [avg_value[mode] for mode in sim_modes]
-        stderr_list = numpy.array([stderr_value[mode] for mode in sim_modes])
+            if 'md' in sim_mode:
+                potential_energy_samples[sim_mode].extend(
+                    log_traj['log/md/compute/ThermodynamicQuantities'
+                                  '/potential_energy'])
+            else:
+                potential_energy_samples[sim_mode].extend(
+                    log_traj['log/hpmc/pair/user/CPPPotentialUnion/energy']
+                         * job.statepoint.kT)
 
-        value_diff_list = numpy.array(value_list) - expected
+            if 'md' in sim_mode:
+                pressure_samples[sim_mode].extend(
+                    log_traj[
+                        'log/md/compute/ThermodynamicQuantities/pressure'])
+            else:
+                pressure_samples[sim_mode].extend(
+                    [job.statepoint.pressure])
 
-        ax.errorbar(x=range(len(sim_modes)),
-                    y=value_diff_list,
-                    yerr=numpy.fabs(stderr_list),
-                    fmt='s')
-        ax.set_xticks(range(len(sim_modes)), sim_modes, rotation=45)
-        ax.set_ylabel(name)
-        ax.hlines(y=0,
-                  xmin=0,
-                  xmax=len(sim_modes) - 1,
-                  linestyles='dashed',
-                  colors='k')
+            density_samples[sim_mode].extend(
+                log_traj['log/custom_actions/ComputeDensity/density'])
 
-    ax = fig.add_subplot(3, 2, 1)
-    plot_vs_expected(ax, ke_translate_means, 1 / 2 * n_dof_translate * kT,
-                     r'$<KE_{\mathrm{translate}}> - 1/2 N_{dof} k T$')
+    ax = fig.add_subplot(4, 2, 1)
+    util.plot_vs_expected(ax, ke_translate_means_expected, r'$<K_\mathrm{translate}> - 1/2 N_{dof} k T$')
 
-    ax = fig.add_subplot(3, 2, 2)
-    # https://doi.org/10.1371/journal.pone.0202764
-    plot_vs_expected(
-        ax, ke_translate_sigmas,
-        1 / math.sqrt(2) * math.sqrt(n_dof_translate) * kT,
-        r'$\Delta KE_{\mathrm{translate}} - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
+    ax = fig.add_subplot(4, 2, 2)
+    util.plot_vs_expected(ax, ke_translate_sigmas_expected,
+                          r'$\Delta K_\mathrm{translate} - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
 
-    ax = fig.add_subplot(3, 2, 3)
-    plot_vs_expected(ax, ke_rotate_means, 1 / 2 * n_dof_rotate * kT,
-                     r'$<KE_{\mathrm{rotate}}> - 1/2 N_{dof} k T$')
+    ax = fig.add_subplot(4, 2, 3)
+    util.plot_vs_expected(ax, ke_rotate_means_expected, r'$<K_\mathrm{rotate}> - 1/2 N_{dof} k T$')
 
-    ax = fig.add_subplot(3, 2, 4)
-    plot_vs_expected(
-        ax, ke_rotate_sigmas, 1 / math.sqrt(2) * math.sqrt(n_dof_rotate) * kT,
-        r'$\Delta KE_{\mathrm{rotate}} - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
+    ax = fig.add_subplot(4, 2, 4)
+    util.plot_vs_expected(ax, ke_rotate_sigmas_expected,
+                          r'$\Delta K_\mathrm{rotate} - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
 
-    ax = fig.add_subplot(3, 2, 5)
-    plot_vs_expected(ax, ke_total_means, 1 / 2 * n_dof_total * kT,
-                     r'$<KE_{\mathrm{total}}> - 1/2 N_{dof} k T$')
+    ax = fig.add_subplot(4, 2, 5)
+    rv = scipy.stats.gamma(3 * job.statepoint.num_particles / 2,
+                           scale=job.statepoint.kT)
+    util.plot_distribution(ax, ke_translate_samples, r'$K_\mathrm{translate}$', expected=rv.pdf)
+    ax.legend(loc='upper right', fontsize='xx-small')
 
-    ax = fig.add_subplot(3, 2, 6)
-    plot_vs_expected(
-        ax, ke_total_sigmas, 1 / math.sqrt(2) * math.sqrt(n_dof_total) * kT,
-        r'$\Delta KE_{\mathrm{total}} - 1/\sqrt{2} \sqrt{N_{dof}} k T$')
+    ax = fig.add_subplot(4, 2, 6)
+    util.plot_distribution(ax, ke_rotate_samples, r'$K_\mathrm{rotate}$', expected=rv.pdf)
 
-    filename = f'lj_union_ke_analyze_kT{kT}_density{round(set_density, 2)}.svg'
+    ax = fig.add_subplot(4, 4, 13)
+    util.plot_distribution(ax, potential_energy_samples, 'U')
+
+    ax = fig.add_subplot(4, 4, 14)
+    util.plot_distribution(ax,
+                           density_samples,
+                           r'$\rho$',
+                           expected=job.statepoint.density)
+
+    ax = fig.add_subplot(4, 4, 15)
+    util.plot_distribution(ax,
+                           pressure_samples,
+                           'P',
+                           expected=job.statepoint.pressure)
+
+    filename = f'lj_union_distribution_analyze_kT{kT}_density{round(set_density, 2)}.svg'
     fig.savefig(os.path.join(jobs[0]._project.path, filename),
                 bbox_inches='tight')
 
     for job in jobs:
-        job.document['lj_union_ke_analyze_complete'] = True
+        job.document['lj_union_distribution_analyze_complete'] = True
 
 
 #################################
@@ -1244,7 +1276,7 @@ def lj_union_ke_analyze(*jobs):
 #################################
 
 
-def run_nve_md_sim(job, device, run_length):
+def run_nve_md_sim(job, device, run_length, complete_filename):
     """Run the MD simulation in NVE."""
     import hoomd
 
@@ -1264,7 +1296,7 @@ def run_nve_md_sim(job, device, run_length):
                              initial_state,
                              nve,
                              sim_mode,
-                             period_multiplier=400)
+                             period_multiplier=200)
 
     if not is_restarting:
         sim.state.thermalize_particle_momenta(
@@ -1277,9 +1309,10 @@ def run_nve_md_sim(job, device, run_length):
         sim=sim,
         end_step=RANDOMIZE_STEPS + EQUILIBRATE_STEPS + run_length,
         steps=500_000,
-        walltime_stop=CONFIG["max_walltime"] * 3600 - 10 * 60)
+        walltime_stop=WALLTIME_STOP_SECONDS)
 
     if sim.timestep == RANDOMIZE_STEPS + EQUILIBRATE_STEPS + run_length:
+        pathlib.Path(job.fn(complete_filename)).touch()
         device.notice('Done.')
     else:
         device.notice('Ending run early due to walltime limits at:'
@@ -1306,65 +1339,88 @@ partition_jobs_gpu_nve = aggregator.groupsof(num=min(
                                              sort_by='density',
                                              select=is_lj_union_nve)
 
+nve_md_sampling_jobs = []
+nve_md_job_definitions = [
+    {
+        'device_name': 'cpu',
+        'ranks_per_partition': NUM_CPU_RANKS,
+        'aggregator': partition_jobs_cpu_mpi_nve,
+        'run_length': 10_000_000,
+    },
+]
 
-@Project.pre.after(lj_union_create_initial_state)
-@Project.post(
-    util.gsd_step_greater_equal_function('nve_md_cpu_quantities.gsd',
-                                         200_000_000))
-@Project.operation(directives=dict(
-    walltime=CONFIG["max_walltime"],
-    executable=CONFIG["executable"],
-    nranks=util.total_ranks_function(NUM_CPU_RANKS)),
-                   aggregator=partition_jobs_cpu_mpi_nve)
-def lj_union_nve_md_cpu(*jobs):
-    """Run NVE MD on the CPU."""
-    import hoomd
-
-    communicator = hoomd.communicator.Communicator(
-        ranks_per_partition=NUM_CPU_RANKS)
-    job = jobs[communicator.partition]
-
-    if communicator.rank == 0:
-        print('starting lj_union_nve_md_cpu:', job)
-
-    device = hoomd.device.CPU(communicator=communicator,
-                              message_filename=job.fn('run_nve_md_cpu.log'))
-    run_nve_md_sim(job, device, run_length=200_000_000)
+if CONFIG["enable_gpu"]:
+    nve_md_job_definitions.extend([
+        {
+            'device_name': 'gpu',
+            'ranks_per_partition': 1,
+            'aggregator': partition_jobs_gpu_nve,
+            'run_length': 100_000_000,
+        },
+    ])
 
 
-@Project.pre.after(lj_union_create_initial_state)
-@Project.post(
-    util.gsd_step_greater_equal_function('nve_md_gpu_quantities.gsd',
-                                         800_000_000))
-@Project.operation(directives=dict(walltime=CONFIG["max_walltime"],
-                                   executable=CONFIG["executable"],
-                                   nranks=util.total_ranks_function(1),
-                                   ngpu=util.total_ranks_function(1)),
-                   aggregator=partition_jobs_gpu_nve)
-def lj_union_nve_md_gpu(*jobs):
-    """Run NVE MD on the GPU."""
-    import hoomd
+def add_nve_md_job(device_name, ranks_per_partition, aggregator, run_length):
+    """Add a MD NVE conservation job to the workflow."""
+    sim_mode = 'nve_md'
 
-    communicator = hoomd.communicator.Communicator(ranks_per_partition=1)
-    job = jobs[communicator.partition]
+    directives = dict(walltime=CONFIG["max_walltime"],
+                      executable=CONFIG["executable"],
+                      nranks=util.total_ranks_function(ranks_per_partition))
 
-    if communicator.rank == 0:
-        print('starting lj_union_nve_md_gpu:', job)
+    if device_name == 'gpu':
+        directives['ngpu'] = util.total_ranks_function(ranks_per_partition)
 
-    device = hoomd.device.GPU(communicator=communicator,
-                              message_filename=job.fn('run_nve_md_gpu.log'))
-    run_nve_md_sim(job, device, run_length=800_000_000)
+    @Project.pre.after(lj_union_create_initial_state)
+    @Project.post.isfile(f'{sim_mode}_{device_name}_complete')
+    @Project.operation(name=f'lj_union_{sim_mode}_{device_name}',
+                       directives=directives,
+                       aggregator=aggregator)
+    def lj_union_nve_md_job(*jobs):
+        """Run NVE MD."""
+        import hoomd
+
+        communicator = hoomd.communicator.Communicator(
+            ranks_per_partition=ranks_per_partition)
+        job = jobs[communicator.partition]
+
+        if communicator.rank == 0:
+            print(f'starting lj_union_{sim_mode}_{device_name}:', job)
+
+        if device_name == 'gpu':
+            device_cls = hoomd.device.GPU
+        elif device_name == 'cpu':
+            device_cls = hoomd.device.CPU
+
+        device = device_cls(
+            communicator=communicator,
+            message_filename=job.fn(f'{sim_mode}_{device_name}.log'))
+        run_nve_md_sim(job,
+                       device,
+                       run_length=run_length,
+                       complete_filename=f'{sim_mode}_{device_name}_complete')
+
+        if communicator.rank == 0:
+            print(f'completed lj_union_{sim_mode}_{device_name} '
+                  f'{job} in {communicator.walltime} s')
+
+    nve_md_sampling_jobs.append(lj_union_nve_md_job)
+
+for definition in nve_md_job_definitions:
+    add_nve_md_job(**definition)
+
+nve_analysis_aggregator = aggregator.groupby(
+    key=['kT', 'density', 'num_particles'],
+    sort_by='replicate_idx',
+    select=is_lj_union_nve)
 
 
-@Project.pre(lambda *jobs: util.gsd_step_greater_equal_function(
-    'nve_md_gpu_quantities.gsd', 800_000_000)(*jobs[0:NUM_NVE_RUNS]))
-@Project.pre(lambda *jobs: util.gsd_step_greater_equal_function(
-    'nve_md_cpu_quantities.gsd', 200_000_000)(*jobs[0:NUM_NVE_RUNS]))
+@Project.pre.after(*nve_md_sampling_jobs)
 @Project.post(lambda *jobs: util.true_all(
-    *jobs[0:NUM_NVE_RUNS], key='lj_union_conservation_analysis_complete'))
+    *jobs, key='lj_union_conservation_analysis_complete'))
 @Project.operation(directives=dict(walltime=CONFIG['short_walltime'],
                                    executable=CONFIG["executable"]),
-                   aggregator=analysis_aggregator)
+                   aggregator=nve_analysis_aggregator)
 def lj_union_conservation_analyze(*jobs):
     """Analyze the output of NVE simulations and inspect conservation."""
     import gsd.hoomd
@@ -1373,53 +1429,53 @@ def lj_union_conservation_analyze(*jobs):
     import matplotlib
     import matplotlib.style
     import matplotlib.figure
-    matplotlib.style.use('ggplot')
-    from util import read_gsd_log_trajectory, get_log_quantity
+    matplotlib.style.use('fivethirtyeight')
 
     print('starting lj_union_conservation_analyze:', jobs[0])
 
-    sim_modes = ['nve_md_cpu', 'nve_md_gpu']
-    jobs = jobs[0:NUM_NVE_RUNS]
+    sim_modes = ['nve_md_cpu']
+    if os.path.exists(jobs[0].fn('nve_md_gpu_quantities.gsd')):
+        sim_modes.extend(['nve_md_gpu'])
 
+    timesteps = []
     energies = []
     linear_momenta = []
 
     for job in jobs:
+        job_timesteps = {}
         job_energies = {}
         job_linear_momentum = {}
 
         for sim_mode in sim_modes:
-            with gsd.hoomd.open(job.fn(sim_mode
-                                       + '_quantities.gsd')) as gsd_traj:
-                # read GSD file once
-                traj = read_gsd_log_trajectory(gsd_traj)
+            log_traj = gsd.hoomd.read_log(job.fn(sim_mode + '_quantities.gsd'))
+
+            job_timesteps[sim_mode] = log_traj['configuration/step']
 
             job_energies[sim_mode] = (
-                get_log_quantity(
-                    traj, 'md/compute/ThermodynamicQuantities/potential_energy')
-                + get_log_quantity(
-                    traj, 'md/compute/ThermodynamicQuantities/kinetic_energy'))
+                log_traj['md/compute/ThermodynamicQuantities/potential_energy']
+                + log_traj['md/compute/ThermodynamicQuantities/kinetic_energy'])
             job_energies[sim_mode] = (
                 job_energies[sim_mode]
                 - job_energies[sim_mode][0]) / job.statepoint["num_particles"]
 
-            momentum_vector = get_log_quantity(traj,
-                                               'md/Integrator/linear_momentum')
+            momentum_vector = log_traj['log/md/Integrator/linear_momentum']
             job_linear_momentum[sim_mode] = [
-                math.sqrt(v[0]**2 + v[1]**2 + v[2]**2) for v in momentum_vector
+                math.sqrt(v[0]**2 + v[1]**2 + v[2]**2)
+                / job.statepoint["num_particles"] for v in momentum_vector
             ]
 
+        timesteps.append(job_timesteps)
         energies.append(job_energies)
-
         linear_momenta.append(job_linear_momentum)
 
     # Plot results
     def plot(*, ax, data, quantity_name, legend=False):
         for i, job in enumerate(jobs):
             for mode in sim_modes:
-                ax.plot(numpy.asarray(data[i][mode]),
+                ax.plot(timesteps[i][mode],
+                        data[i][mode],
                         label=f'{mode}_{job.statepoint.replicate_idx}')
-        ax.set_xlabel("frame")
+        ax.set_xlabel("time step")
         ax.set_ylabel(quantity_name)
 
         if legend:
@@ -1430,9 +1486,11 @@ def lj_union_conservation_analyze(*jobs):
     plot(ax=ax, data=energies, quantity_name=r"$E / N$", legend=True)
 
     ax = fig.add_subplot(2, 1, 2)
-    plot(ax=ax, data=linear_momenta, quantity_name=r"$p$")
+    plot(ax=ax,
+         data=linear_momenta,
+         quantity_name=r"$\left| \vec{p} \right| / N$")
 
-    fig.suptitle("LJ conservation tests: "
+    fig.suptitle("LJ union conservation tests: "
                  f"$kT={job.statepoint.kT}$, $\\rho={job.statepoint.density}$, "
                  f"$N={job.statepoint.num_particles}$")
     filename = f'lj_union_conservation_kT{job.statepoint.kT}_' \

--- a/hoomd_validation/util.py
+++ b/hoomd_validation/util.py
@@ -266,11 +266,15 @@ def plot_vs_expected(ax,
     """Plot values vs an expected value."""
     sim_modes = values.keys()
 
-    avg_value = {mode: numpy.mean(values[mode]) for mode in sim_modes}
-    stderr_value = {
-        mode: 2 * numpy.std(values[mode]) / numpy.sqrt(len(values[mode]))
-        for mode in sim_modes
-    }
+    avg_value = {}
+    stderr_value = {}
+    for mode in sim_modes:
+        if numpy.all(numpy.isnan(values[mode])):
+           avg_value[mode] = numpy.nan
+           stderr_value[mode] = numpy.nan
+        else:
+            avg_value[mode] = numpy.mean(values[mode])
+            stderr_value[mode] = 2 * numpy.std(values[mode]) / numpy.sqrt(len(values[mode]))
 
     # compute the energy differences
     value_list = [avg_value[mode] for mode in sim_modes]
@@ -293,9 +297,9 @@ def plot_vs_expected(ax,
     if separate_nvt_npt:
         # Indicate average nvt and npt values separately.
         npt_modes = list(filter(lambda x: 'npt' in x, sim_modes))
-        npt_mean = numpy.mean([avg_value[mode] for mode in npt_modes])
+        npt_mean = numpy.nanmean([avg_value[mode] for mode in npt_modes])
         nvt_modes = list(filter(lambda x: 'nvt' in x, sim_modes))
-        nvt_mean = numpy.mean([avg_value[mode] for mode in nvt_modes])
+        nvt_mean = numpy.nanmean([avg_value[mode] for mode in nvt_modes])
 
         if relative_scale is not None:
             npt_mean = (npt_mean - expected) / expected * relative_scale
@@ -352,3 +356,8 @@ def plot_timeseries(ax,
                   xmax=timesteps[provided_modes[0]][-1],
                   linestyles='dashed',
                   colors='k')
+
+
+def _sort_sim_modes(sim_modes):
+    """Sort simulation modes for comparison."""
+    sim_modes.sort(key=lambda x: ('nvt' in x, 'md' in x, x))

--- a/hoomd_validation/util.py
+++ b/hoomd_validation/util.py
@@ -270,11 +270,12 @@ def plot_vs_expected(ax,
     stderr_value = {}
     for mode in sim_modes:
         if numpy.all(numpy.isnan(values[mode])):
-           avg_value[mode] = numpy.nan
-           stderr_value[mode] = numpy.nan
+            avg_value[mode] = numpy.nan
+            stderr_value[mode] = numpy.nan
         else:
             avg_value[mode] = numpy.mean(values[mode])
-            stderr_value[mode] = 2 * numpy.std(values[mode]) / numpy.sqrt(len(values[mode]))
+            stderr_value[mode] = 2 * numpy.std(values[mode]) / numpy.sqrt(
+                len(values[mode]))
 
     # compute the energy differences
     value_list = [avg_value[mode] for mode in sim_modes]


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Port improvements made in #56 to `lj-union`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Make consistent plots, reuse code in util, and allow `lj-union` to be run on the CPU only.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I executed the `lj-union` tests on Bridges-2 and Delta. Results: 
![lj_union_compare_kT1 5_density0 04](https://github.com/glotzerlab/hoomd-validation/assets/2197568/83ec0f01-cc59-4eed-ad03-32415897fb93)
![lj_union_conservation_kT1 5_density0 04_N512](https://github.com/glotzerlab/hoomd-validation/assets/2197568/33e2de9b-89ed-41ef-8921-7e41a9299c57)
![lj_union_distribution_analyze_kT1 5_density0 04](https://github.com/glotzerlab/hoomd-validation/assets/2197568/539b61c5-739e-4e3c-a513-c2f37c668cda)

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-validation/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
